### PR TITLE
Remove the role selection dialog (bsc#1055071)

### DIFF
--- a/control/installation.leanos.xml
+++ b/control/installation.leanos.xml
@@ -110,96 +110,7 @@ textdomain="control"
 
     </partitioning>
 
-
-
-    <texts>
-        <roles_caption>
-          <!-- TRANSLATORS: dialog caption -->
-          <label>System Role</label>
-        </roles_caption>
-        <roles_text>
-          <!-- TRANSLATORS: label in a dialog -->
-          <label>System Roles are predefined use cases which tailor the system
-for the selected scenario.</label>
-        </roles_text>
-        <roles_help>
-          <!-- TRANSLATORS: dialog help -->
-          <label>&lt;p&gt;The system roles adjustments are in the range from package selection up
-to disk partitioning. By choosing a system role, the system is
-configured accordingly to match the use case of the role. The settings
-defined by a role can be overridden in the next steps if necessary.&lt;/p&gt;</label>
-        </roles_help>
-        <normal_role>
-          <!-- TRANSLATORS: a label for a system role -->
-          <label>Default System</label>
-        </normal_role>
-        <normal_role_description>
-          <label>• GNOME environment, with Btrfs root (/) partition
-• Separate /home partition (XFS) for disks larger than 20GB</label>
-        </normal_role_description>
-        <kvm_host_role>
-          <!-- TRANSLATORS: a label for a system role -->
-          <label>KVM Virtualization Host</label>
-        </kvm_host_role>
-        <kvm_host_role_description>
-          <label>• Kernel-based hypervisor and tools
-• No separate /home partition</label>
-        </kvm_host_role_description>
-        <xen_host_role>
-          <!-- TRANSLATORS: a label for a system role -->
-          <label>Xen Virtualization Host</label>
-        </xen_host_role>
-        <xen_host_role_description>
-          <label>• Bare metal hypervisor and tools
-• No separate /home partition</label>
-        </xen_host_role_description>
-    </texts>
-
     <update>
-      <system_roles>
-        <insert_system_roles config:type="list">
-          <insert_system_role>
-            <!-- FATE#317481 -->
-            <system_roles config:type="list">
-              <system_role>
-                <!-- the id is a key for texts/$id/label
-                                     and texts/$id_description/label below -->
-                <id>normal_role</id>
-                <!-- nothing is overlaid for the normal role -->
-              </system_role>
-
-              <system_role>
-                <id>kvm_host_role</id>
-
-                <!-- the rest is overlaid over the feature sections and values. -->
-                <partitioning>
-                  <try_separate_home config:type="boolean">false</try_separate_home>
-                </partitioning>
-                <software>
-                  <default_patterns>base Minimal kvm_server</default_patterns>
-                  <!-- the cdata trick produces an empty string in the data
-                       instead of omitting the key entirely -->
-                  <optional_default_patterns><![CDATA[]]></optional_default_patterns>
-                  <default_desktop><![CDATA[]]></default_desktop>
-                </software>
-              </system_role>
-
-              <system_role>
-                <id>xen_host_role</id>
-
-                <partitioning>
-                  <try_separate_home config:type="boolean">false</try_separate_home>
-                </partitioning>
-                <software>
-                  <default_patterns>base Minimal xen_server</default_patterns>
-                  <optional_default_patterns><![CDATA[]]></optional_default_patterns>
-                  <default_desktop><![CDATA[]]></default_desktop>
-                </software>
-              </system_role>
-            </system_roles>
-          </insert_system_role>
-        </insert_system_roles>
-      </system_roles>
 
       <workflows config:type="list">
         <workflow>
@@ -225,10 +136,6 @@ defined by a role can be overridden in the next steps if necessary.&lt;/p&gt;</l
                 <name>download_release_notes</name>
             </module>
             <module>
-                <name>system_role</name>
-                <archs>i386,x86_64</archs>
-            </module>
-             <module>
                 <label>Disk</label>
                 <name>disk_proposal</name>
                 <enable_back>yes</enable_back>

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Aug 23 12:39:12 UTC 2017 - lslezak@suse.cz
+
+- Remove the role selection dialog from the installation workflow
+  (bsc#1055071)
+- 15.0.3
+
+-------------------------------------------------------------------
 Wed Aug  2 08:22:14 UTC 2017 - jreidinger@suse.com
 
 - add product selector client (FATE#323450)

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -91,7 +91,7 @@ Provides:       system-installation() = leanos
 
 Url:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.0.2
+Version:        15.0.3
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
There should be no role selection dialog in the LeanOS installation, see https://bugzilla.suse.com/show_bug.cgi?id=1055071

- 15.0.3