### PR TITLE
Added yast2-s390 dependency (bsc#1055871)

### DIFF
--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Sep  1 08:41:23 UTC 2017 - lslezak@suse.cz
+
+- Added yast2-s390 dependency to fix failed disk activation
+  (bsc#1055871)
+- 15.0.5
+
+-------------------------------------------------------------------
 Wed Aug 23 13:33:50 UTC 2017 - igonzalezsosa@suse.com
 
 - Add inst_repositories_initialization client in order to

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -78,6 +78,7 @@ Requires:       yast2-rdp
 #
 %ifarch s390 s390x
 Requires:       yast2-reipl >= 3.1.4
+Requires:       yast2-s390
 %endif
 
 %ifarch %ix86 x86_64
@@ -91,7 +92,7 @@ Provides:       system-installation() = leanos
 
 Url:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.0.4
+Version:        15.0.5
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
...to fix failed disk activation. Originally the `yast2-s390` was included in inst-sys as an `yast2-storage` dependency. With `yast2-storage-ng` this dependency has been dropped so we need to add it here.

See https://bugzilla.suse.com/show_bug.cgi?id=1055871.



- 15.0.5