### PR TITLE
Add SCC/SMT upgrade repositories in the upgrade workflow (fate#323163)

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -573,12 +573,10 @@ Please visit us at http://www.suse.com/.
                     <name>upgrade_urls</name>
                     <enable_back>yes</enable_back>
                 </module>
-<!--
                 <module>
-                    <name>scc</name>
+                    <name>migration_repos</name>
                     <enable_back>yes</enable_back>
                 </module>
--->
                 <module>
                     <label>Add-On Products</label>
                     <name>add-on</name>

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Oct  2 13:34:02 UTC 2017 - lslezak@suse.cz
+
+- Add SCC/SMT upgrade repositories in the upgrade workflow
+  (fate#323163)
+- 15.0.10
+
+-------------------------------------------------------------------
 Fri Sep 22 08:14:41 UTC 2017 - jreidinger@suse.com
 
 - add work-around when default desktop is unselected. Real fix is

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -92,7 +92,7 @@ Provides:       system-installation() = leanos
 
 Url:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.0.9
+Version:        15.0.10
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
- 15.0.10

- Currently it uses the SP migration workflow so you can actually upgrade only from SLES-12-SP2 to SP3 using the SLE15 media. That's not exactly what we want in the feature but that will be fixed later in that client (requires changes in the SCC API).

- Tested manually with an adjusted `control.xml` and with small changes in the registration module (will be submitted separately).

- More details in https://fate.suse.com/323163