### PR TITLE
add sap-installation-wizard (fate#323792)

### DIFF
--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Oct 25 13:18:01 CEST 2017 - snwint@suse.de
+
+- add sap-installation-wizard (fate#323792)
+- 15.0.17
+
+-------------------------------------------------------------------
 Wed Oct 11 11:49:10 UTC 2017 - jreidinger@suse.com
 
 - define self-update ID as media is multi-product one

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -85,6 +85,10 @@ Requires:       yast2-s390
 Requires:       yast2-vm
 %endif
 
+%ifarch x86_64 ppc64le
+Requires:       sap-installation-wizard
+%endif
+
 #
 ######################################################################
 

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -94,7 +94,7 @@ Requires:       sap-installation-wizard
 
 Url:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.0.16
+Version:        15.0.17
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
There's no longer a special sles-sap install medium. It's all part of the common installer.