### PR TITLE
S390 firewall proposal

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -271,7 +271,7 @@ Please visit us at http://www.suse.com/.
                     <presentation_order>75</presentation_order>
                 </proposal_module>
                 <proposal_module>
-                    <name>firewall_stage1</name>
+                    <name>firewall</name>
                     <presentation_order>50</presentation_order>
                 </proposal_module>
                 <!-- Fate #319624 - proposal and dialog for existing SSH host keys -->

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Nov  8 17:22:12 UTC 2017 - knut.anderssen@suse.com
+
+- Use of the new firewall proposal also in s390 arch (bsc#1067180)
+- 15.0.20
+
+-------------------------------------------------------------------
 Tue Nov 02 08:31:37 UTC 2017 - knut.anderssen@suse.com
 
 - Unification of firewall proposals (fate#323460)

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -94,7 +94,7 @@ Requires:       sap-installation-wizard
 
 Url:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.0.19
+Version:        15.0.20
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1067180

In #18 we modified the firewall proposal but not for s390, with this PR we fixed that.

The installation was working but was calling the firewall_stage1 proposal instead of firewall one.