### PR TITLE
Pattern "gnome-basic" has been renamed to "gnome_basic" (bsc#1069728)

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -117,7 +117,7 @@ textdomain="control"
             <window_manager>
               <sysconfig_wm>gnome</sysconfig_wm>
               <check_packages>gnome-session</check_packages>
-              <install_patterns>gnome-basic</install_patterns>
+              <install_patterns>gnome_basic</install_patterns>
               <install_packages>gdm gnome-shell-classic</install_packages>
             </window_manager>
           </window_managers>

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan  4 16:39:33 UTC 2018 - lslezak@suse.cz
+
+- Pattern "gnome-basic" has been renamed to "gnome_basic"
+  (bsc#1069728)
+- 15.0.22
+
+-------------------------------------------------------------------
 Fri Dec  1 16:00:12 CET 2017 - schubi@suse.de
 
 - AutoYaST installation: Adding DriverUpdate repo via module

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -94,7 +94,7 @@ Requires:       sap-installation-wizard
 
 Url:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.0.21
+Version:        15.0.22
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
- Fix for https://bugzilla.suse.com/show_bug.cgi?id=1069728
- 15.0.22