### PR TITLE
Add 'fcoe-client' to the list of clonable modules

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -143,6 +143,7 @@ textdomain="control"
         <clone_module>ca_mgm</clone_module>
         <clone_module>add-on</clone_module>
         <clone_module>iscsi-client</clone_module>
+        <clone_module>fcoe-client</clone_module>
         <clone_module>software</clone_module>
         <clone_module>partitioning</clone_module>
         <clone_module>bootloader</clone_module>

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar  8 12:35:04 UTC 2018 - knut.anderssen@suse.com
+
+- Added the fcoe-client to the list of clonable modules
+  (bsc#1078991).
+- 15.0.27
+
+-------------------------------------------------------------------
 Tue Feb 13 10:32:07 CET 2018 - schubi@suse.de
 
 - Adding tftp-server to clone_modules section in order to export

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -96,7 +96,7 @@ Requires:       sap-installation-wizard
 
 Url:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.0.26
+Version:        15.0.27
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
- https://trello.com/c/eLMiRWmH/1350-2-bug-1078991-l3-autoyast-unable-to-find-disk-with-option-withfcoe