### PR TITLE
Use the SLE15-SP1 self update repository fallback (bsc#1116916)

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -71,7 +71,7 @@ textdomain="control"
         </services_proposal>
 
 	<!-- self-update URL -->
-	<self_update_url>https://updates.suse.com/SUSE/Updates/SLE-INSTALLER/15/$arch/update</self_update_url>
+	<self_update_url>https://updates.suse.com/SUSE/Updates/SLE-INSTALLER/15-SP1/$arch/update</self_update_url>
 	<!-- self-update ID. SCC recognize for SLE15 ID SLES -->
 	<self_update_id>SLES</self_update_id>
 

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Nov 21 14:24:29 UTC 2018 - lslezak@suse.cz
+
+- Updated the self update repository fallback URL to use the
+  SLE15-SP1 repository instead of the SLE15-GA (bsc#1116916)
+- 15.1.0
+
+-------------------------------------------------------------------
 Fri Oct 12 14:16:31 CEST 2018 - schubi@suse.de
 
 - Added tags full_system_media_name and full_system_download_url

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -96,7 +96,7 @@ Requires:       sap-installation-wizard
 
 Url:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.0.31
+Version:        15.1.0
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
- The fallback URL needs to be updated to SP1
- 15.1.0

## Notes

- The https://nu.novell.com/SUSE/Updates/SLE-INSTALLER/15-SP1/ repository does not exist yet, but there already is https://nu.novell.com/SUSE/Updates/SLE-Product-SLES/15-SP1/ so I suppose it will use the same product version (`15-SP1`).
- We can update that later if needed, but for now using the SLE15-GA repository is completely wrong, it actually downgrades(!) some YaST packages in the inst-sys.