### PR TITLE
Disable the CD/DVD installation repository (bsc#1124327)

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -109,6 +109,9 @@ textdomain="control"
         <!-- BNC #435479: Show support status in package details -->
         <display_support_status config:type="boolean">true</display_support_status>
 
+        <!-- Disable the CD/DVD installation medium after finishing the installation (jsc#SLE-3191) -->
+        <disable_media_repo config:type="boolean">true</disable_media_repo>
+
         <!-- handling software proposal during product upgrade -->
         <upgrade>
           <window_managers config:type="list">

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb  7 10:11:21 UTC 2019 - lslezak@suse.cz
+
+- Disable the CD/DVD installation repository (bsc#1124327,
+  fate#325541, jsc#SLE-3191)
+- 15.1.2
+
+-------------------------------------------------------------------
 Thu Nov 29 14:10:25 UTC 2018 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Update yast2-theme dependency (boo#1108422)

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -96,7 +96,7 @@ Requires:       sap-installation-wizard
 
 Url:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.1.1
+Version:        15.1.2
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
- This is a missing part for https://fate.suse.com/325541
- Michal adapted the code (https://github.com/yast/yast-packager/pull/157), updated the schema definition (https://github.com/yast/yast-installation-control/pull/7) but forgot to actually add the new option into the control file.