### PR TITLE
Update base product license directory

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -46,7 +46,7 @@ textdomain="control"
         </save_instsys_content>
 
         <!-- FATE: #304865: Enhance YaST Modules to cooperate better handling the product licenses -->
-        <base_product_license_directory>/etc/YaST2/licenses/base/</base_product_license_directory>
+        <base_product_license_directory>/usr/share/licenses/product/base/</base_product_license_directory>
 
         <!-- FATE: #303893: Default to enabled kdump -->
         <enable_kdump config:type="boolean">true</enable_kdump>

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar 12 14:59:23 UTC 2019 - David Díaz <dgonzalez@suse.com>
+
+- Updated the base product license directory
+  (fate#324053, jsc#SLE-4173)
+- 15.1.3
+
+-------------------------------------------------------------------
 Thu Feb  7 10:11:21 UTC 2019 - lslezak@suse.cz
 
 - Disable the CD/DVD installation repository (bsc#1124327,

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -96,7 +96,7 @@ Requires:       sap-installation-wizard
 
 Url:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.1.2
+Version:        15.1.3
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
After the changes made for fate#324053 / jsc#SLE-4173, the license for the base product will be located at `/usr/share/licenses/product/base` instead of `/etc/YaST2/licenses/base`.

---

Related to https://github.com/yast/yast-yast2/pull/907