### PR TITLE
Adapt system media name for SP2

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -76,7 +76,7 @@ textdomain="control"
 	<self_update_id>SLES</self_update_id>
 
 	<!-- Information about required media if the user has skipped the registration -->
-	<full_system_media_name>SLE-15-SP1-Packages</full_system_media_name>
+	<full_system_media_name>SLE-15-SP2-Packages</full_system_media_name>
 	<full_system_download_url>https://download.suse.com</full_system_download_url>
 
     </globals>

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul 17 15:13:28 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Update system media name (bsc#1141835).
+- 15.1.4
+
+-------------------------------------------------------------------
 Tue Mar 12 14:59:23 UTC 2019 - David Díaz <dgonzalez@suse.com>
 
 - Updated the base product license directory

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -96,7 +96,7 @@ Requires:       sap-installation-wizard
 
 Url:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.1.3
+Version:        15.1.4
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
Just, 

> Adapt leanos control file to indicate new product name.

* https://bugzilla.suse.com/show_bug.cgi?id=1141835

* https://trello.com/c/ZICKGZHE/1150-sles15-sp2-p5-1141835-skip-registration-warning-still-talks-about-15-sp1