### PR TITLE
Disable self-update in the quarterly media updates (bsc#1150012)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,11 @@
 require "yast/rake"
 
-Yast::Tasks.submit_to :sle15sp1
-
 Yast::Tasks.configuration do |conf|
+  conf.obs_api = "https://api.suse.de"
+  conf.obs_target = "SUSE_SLE-15-SP1_Update_QR"
+  conf.obs_sr_project = "SUSE:SLE-15-SP1:Update:QR"
+  conf.obs_project = "Devel:YaST:SLE-15-SP1-QR"
+
   # lets ignore license check for now
   conf.skip_license_check << /.*/
 end

--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -70,10 +70,12 @@ textdomain="control"
             </service>
         </services_proposal>
 
+	<!-- Note: the self update step ("update_installer") is disabled
+	     for quarterly media respins, the data below would be ignored anyway. -->
 	<!-- self-update URL -->
-	<self_update_url>https://updates.suse.com/SUSE/Updates/SLE-INSTALLER/15-SP1/$arch/update</self_update_url>
+	<!-- <self_update_url>https://updates.suse.com/SUSE/Updates/SLE-INSTALLER/15-SP1/$arch/update</self_update_url> -->
 	<!-- self-update ID. SCC recognize for SLE15 ID SLES -->
-	<self_update_id>SLES</self_update_id>
+	<!-- <self_update_id>SLES</self_update_id> -->
 
 	<!-- Information about required media if the user has skipped the registration -->
 	<full_system_media_name>SLE-15-SP1-Packages</full_system_media_name>
@@ -446,10 +448,14 @@ Please visit us at http://www.suse.com/.
                     <name>setup_dhcp</name>
                 </module>
                 <!-- As soon as possible but after network is initialized -->
+                <!-- Disabled for quarterly media respins, there is in an updated inst-sys
+                    which might contain newer packages than the self update repository -->
+                <!--
                 <module>
                     <label>Installer Update</label>
                     <name>update_installer</name>
                 </module>
+                -->
                 <module>
                     <label>Repositories Initialization</label>
                     <name>repositories_initialization</name>
@@ -508,10 +514,14 @@ Please visit us at http://www.suse.com/.
                     <name>setup_dhcp</name>
                 </module>
                 <!-- As soon as possible but after network is initialized -->
+                <!-- Disabled for quarterly media respins, there is in an updated inst-sys
+                    which might contain newer packages than the self update repository -->
+                <!--
                 <module>
                     <label>Installer Update</label>
                     <name>update_installer</name>
                 </module>
+                -->
                 <module>
                     <label>Repositories Initialization</label>
                     <name>repositories_initialization</name>
@@ -629,12 +639,16 @@ Please visit us at http://www.suse.com/.
             </defaults>
             <modules config:type="list">
                 <!-- As soon as possible -->
+                <!-- Disabled for quarterly media respins, there is in an updated inst-sys
+                    which might contain newer packages than the self update repository -->
+                <!--
                 <module>
                     <label>Installer Update</label>
                     <name>update_installer</name>
                     <enable_back>no</enable_back>
                     <enable_next>yes</enable_next>
                 </module>
+                -->
                 <module>
                     <label>Repositories Initialization</label>
                     <name>repositories_initialization</name>
@@ -673,12 +687,16 @@ Please visit us at http://www.suse.com/.
             <stage>initial</stage>
             <modules config:type="list">
                 <!-- As soon as possible -->
+                <!-- Disabled for quarterly media respins, there is in an updated inst-sys
+                    which might contain newer packages than the self update repository -->
+                <!--
                 <module>
                     <label>Installer Update</label>
                     <name>update_installer</name>
                     <enable_back>no</enable_back>
                     <enable_next>yes</enable_next>
                 </module>
+                -->
                 <module>
                     <label>Repositories Initialization</label>
                     <name>repositories_initialization</name>

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep 16 10:38:02 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Disable YaST self-update in the quarterly media updates
+  (bsc#1150012)
+- 15.1.3.1
+
+-------------------------------------------------------------------
 Tue Mar 12 14:59:23 UTC 2019 - David Díaz <dgonzalez@suse.com>
 
 - Updated the base product license directory

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -96,7 +96,7 @@ Requires:       sap-installation-wizard
 
 Url:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.1.3
+Version:        15.1.3.1
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
## Problem
- The updated (rebuilt) media can contain newer packages than the released self updates
- We need to disable the self-update feature to potentially avoid downgrading the YaST packages in the inst-sys
- See https://bugzilla.suse.com/show_bug.cgi?id=1150012 or https://trello.com/c/oM7EGBZa
- 15.1.3.1
- Use a separate branch for quartertly re-spins (QR), the SP1 will continue towards SP2 with self-update enabled, for this reason use also a separate devel project in IBS and a separate Git branch

## The Fix

- The self-update step has been completely removed from the workflow, the unused self-update data have been commented out (just to avoid a confusion).