### PR TITLE
Added base products for the online installation (jsc#SLE-7214)

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -124,66 +124,69 @@ textdomain="control"
           </window_managers>
         </upgrade>
 
+        <!-- List of the base products used on the OnlineOnly installation medium,
+             in the future the products should be read directly from the registration
+             server (SCC), but that API has not been implemented yet. -->
         <base_products config:type="list">
           <base_product>
             <!-- hidden product -->
             <special_product config:type="boolean">true</special_product>
-            <label>SUSE Linux Enterprise Server 15 SP2 Business Critical Linux</label>
+            <display_name>SUSE Linux Enterprise Server 15 SP2 Business Critical Linux</display_name>
             <name>SLES_BCL</name>
             <version>15.2</version>
             <register_target>sle-15-$arch</register_target>
             <archs>x86_64</archs>
           </base_product>
           <base_product>
-            <label>SUSE Linux Enterprise Server 15 SP2</label>
+            <display_name>SUSE Linux Enterprise Server 15 SP2</display_name>
             <name>SLES</name>
             <version>15.2</version>
             <register_target>sle-15-$arch</register_target>
           </base_product>
           <base_product>
-            <label>SUSE Linux Enterprise High Performance Computing 15 SP2</label>
+            <display_name>SUSE Linux Enterprise High Performance Computing 15 SP2</display_name>
             <name>SLE_HPC</name>
             <version>15.2</version>
             <register_target>sle-15-$arch</register_target>
             <archs>aarch64,x86_64</archs>
           </base_product>
           <base_product>
-            <label>SUSE Linux Enterprise Real Time 15 SP2</label>
+            <display_name>SUSE Linux Enterprise Real Time 15 SP2</display_name>
             <name>SLE_RT</name>
             <version>15.2</version>
             <register_target>sle-15-$arch</register_target>
             <archs>x86_64</archs>
           </base_product>
           <base_product>
-            <label>SUSE Linux Enterprise Server for SAP Applications 15 SP2</label>
+            <display_name>SUSE Linux Enterprise Server for SAP Applications 15 SP2</display_name>
             <name>SLES_SAP</name>
             <version>15.2</version>
             <register_target>sle-15-$arch</register_target>
             <archs>ppc64le,x86_64</archs>
           </base_product>
           <base_product>
-            <label>SUSE Linux Enterprise Desktop 15 SP2</label>
+            <display_name>SUSE Linux Enterprise Desktop 15 SP2</display_name>
             <name>SLED</name>
             <version>15.2</version>
             <register_target>sle-15-$arch</register_target>
             <archs>x86_64</archs>
           </base_product>
           <base_product>
-            <label>SUSE Manager Server 4.0</label>
+            <display_name>SUSE Manager Server 4.0</display_name>
             <name>SUSE-Manager-Server</name>
             <version>4.0</version>
             <register_target>sle-15-$arch</register_target>
             <archs>ppc64le,s390x,x86_64</archs>
           </base_product>
           <base_product>
-            <label>SUSE Manager Proxy 4.0</label>
+            <display_name>SUSE Manager Proxy 4.0</display_name>
             <name>SUSE-Manager-Proxy</name>
             <version>4.0</version>
             <register_target>sle-15-$arch</register_target>
             <archs>x86_64</archs>
           </base_product>
           <base_product>
-            <label>SUSE Manager Retail Branch Server 4.0</label>
+            <display_name>SUSE Manager Retail Branch Server 4.0</display_name>
             <name>SUSE-Manager-Retail-Branch-Server</name>
             <version>4.0</version>
             <register_target>sle-15-$arch</register_target>

--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -123,6 +123,73 @@ textdomain="control"
             </window_manager>
           </window_managers>
         </upgrade>
+
+        <base_products config:type="list">
+          <base_product>
+            <!-- hidden product -->
+            <special_product config:type="boolean">true</special_product>
+            <label>SUSE Linux Enterprise Server 15 SP2 Business Critical Linux</label>
+            <name>SLES_BCL</name>
+            <version>15.2</version>
+            <register_target>sle-15-$arch</register_target>
+            <archs>x86_64</archs>
+          </base_product>
+          <base_product>
+            <label>SUSE Linux Enterprise Server 15 SP2</label>
+            <name>SLES</name>
+            <version>15.2</version>
+            <register_target>sle-15-$arch</register_target>
+          </base_product>
+          <base_product>
+            <label>SUSE Linux Enterprise High Performance Computing 15 SP2</label>
+            <name>SLE_HPC</name>
+            <version>15.2</version>
+            <register_target>sle-15-$arch</register_target>
+            <archs>aarch64,x86_64</archs>
+          </base_product>
+          <base_product>
+            <label>SUSE Linux Enterprise Real Time 15 SP2</label>
+            <name>SLE_RT</name>
+            <version>15.2</version>
+            <register_target>sle-15-$arch</register_target>
+            <archs>x86_64</archs>
+          </base_product>
+          <base_product>
+            <label>SUSE Linux Enterprise Server for SAP Applications 15 SP2</label>
+            <name>SLES_SAP</name>
+            <version>15.2</version>
+            <register_target>sle-15-$arch</register_target>
+            <archs>ppc64le,x86_64</archs>
+          </base_product>
+          <base_product>
+            <label>SUSE Linux Enterprise Desktop 15 SP2</label>
+            <name>SLED</name>
+            <version>15.2</version>
+            <register_target>sle-15-$arch</register_target>
+            <archs>x86_64</archs>
+          </base_product>
+          <base_product>
+            <label>SUSE Manager Server 4.0</label>
+            <name>SUSE-Manager-Server</name>
+            <version>4.0</version>
+            <register_target>sle-15-$arch</register_target>
+            <archs>ppc64le,s390x,x86_64</archs>
+          </base_product>
+          <base_product>
+            <label>SUSE Manager Proxy 4.0</label>
+            <name>SUSE-Manager-Proxy</name>
+            <version>4.0</version>
+            <register_target>sle-15-$arch</register_target>
+            <archs>x86_64</archs>
+          </base_product>
+          <base_product>
+            <label>SUSE Manager Retail Branch Server 4.0</label>
+            <name>SUSE-Manager-Retail-Branch-Server</name>
+            <version>4.0</version>
+            <register_target>sle-15-$arch</register_target>
+            <archs>x86_64</archs>
+          </base_product>
+        </base_products>
     </software>
 
     <network>
@@ -451,8 +518,12 @@ Please visit us at http://www.suse.com/.
                     <name>update_installer</name>
                 </module>
                 <module>
+                    <!-- skip on the Online installation medium, it is done later -->
                     <label>Repositories Initialization</label>
                     <name>repositories_initialization</name>
+                    <arguments>
+                        <skip>online</skip>
+                    </arguments>
                 </module>
                 <module>
                     <name>complex_welcome</name>
@@ -481,6 +552,24 @@ Please visit us at http://www.suse.com/.
                     <name>disks_activate</name>
                     <enable_back>yes</enable_back>
                     <enable_next>yes</enable_next>
+                </module>
+                <module>
+                    <!-- only on the Online installation medium -->
+                    <label>Registration</label>
+                    <name>scc</name>
+                    <enable_back>yes</enable_back>
+                    <enable_next>yes</enable_next>
+                    <arguments>
+                        <only>online</only>
+                    </arguments>
+                </module>
+                <module>
+                    <!-- only on the Online installation medium -->
+                    <label>Repositories Initialization</label>
+                    <name>repositories_initialization</name>
+                    <arguments>
+                        <only>online</only>
+                    </arguments>
                 </module>
                 <module>
                     <label>System Analysis</label>

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Sep 20 19:01:07 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Added base products for the online installation, adapted the
+  installation workflow (jsc#SLE-7214)
+- 15.2.0
+
+-------------------------------------------------------------------
 Wed Jul 17 15:13:28 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - Update system media name (bsc#1141835).

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -31,7 +31,7 @@ Name:           skelcd-control-leanos
 # xmllint (for validation)
 BuildRequires:  libxml2-tools
 # RNG validation schema
-BuildRequires:  yast2-installation-control >= 4.0.11
+BuildRequires:  yast2-installation-control >= 4.2.6
 
 ######################################################################
 #
@@ -60,8 +60,8 @@ Requires:       yast2-multipath
 Requires:       yast2-network >= 3.1.42
 Requires:       yast2-nfs-client
 Requires:       yast2-ntp-client
-# clients/inst_product_upgrade_license.rb
-Requires:       yast2-packager >= 4.0.29
+# online medium support
+Requires:       yast2-packager >= 4.2.27
 Requires:       yast2-proxy
 Requires:       yast2-services-manager
 Requires:       yast2-configuration-management
@@ -96,7 +96,7 @@ Requires:       sap-installation-wizard
 
 Url:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.1.4
+Version:        15.2.0
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
- Added base products, the supported architectures were obtained from http://dist.suse.de/ibs/SUSE:/SLE-15-SP2:/GA:/TEST/images/repo/
- Added extra steps for the online installation workflow (registration, moved repository initialization)
- See https://jira.suse.com/browse/SLE-7214
- The `control.xml` schema has been updated in https://github.com/yast/yast-installation-control/pull/90 and https://github.com/yast/yast-installation-control/pull/91
- Tested manually
- 15.2.0