### PR TITLE
Update for the offline installation medium (jsc#SLE-7101)

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -521,11 +521,13 @@ Please visit us at http://www.suse.com/.
                     <name>update_installer</name>
                 </module>
                 <module>
-                    <!-- skip on the Online installation medium, it is done later -->
+                    <!-- skip on the Online and Offline installation medium, it is done later -->
+                    <!-- TODO: Remove this step completely once the old Installer and
+                      the non-bootable Packages DVD are dropped. -->
                     <label>Repositories Initialization</label>
                     <name>repositories_initialization</name>
                     <arguments>
-                        <skip>online</skip>
+                        <skip>online,offline</skip>
                     </arguments>
                 </module>
                 <module>

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Sep 27 14:40:55 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Adapt the control file for the offline installation medium
+  (jsc#SLE-7101)
+- 15.2.2
+
+-------------------------------------------------------------------
 Tue Sep 24 06:59:14 UTC 2019 - jsrain@suse.cz
 
 - updated product list for on-line installation (jsc#SLE-7214)

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -96,7 +96,7 @@ Requires:       sap-installation-wizard
 
 Url:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.2.1
+Version:        15.2.2
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
- Skip the repository initialization step also on the offline installation medium
- The repository is initialized after the base product is selected by user
- The offline medium contains several base products in separate product subdirectories
- https://jira.suse.com/browse/SLE-7101
- 15.2.2