### PR TITLE
Remove SLE Real Time base product

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -151,13 +151,6 @@ textdomain="control"
             <archs>aarch64,x86_64</archs>
           </base_product>
           <base_product>
-            <display_name>SUSE Linux Enterprise Real Time 15 SP2</display_name>
-            <name>SLE_RT</name>
-            <version>15.2</version>
-            <register_target>sle-15-$arch</register_target>
-            <archs>x86_64</archs>
-          </base_product>
-          <base_product>
             <display_name>SUSE Linux Enterprise Server for SAP Applications 15 SP2</display_name>
             <name>SLES_SAP</name>
             <version>15.2</version>

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Nov 21 09:25:58 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Remove the Real Time base product (jsc#SLE-7104).
+- 15.2.7
+
+-------------------------------------------------------------------
 Tue Nov  5 09:02:38 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - AutoUpgrade support for the Online installation medium

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -96,7 +96,7 @@ Requires:       sap-installation-wizard
 
 Url:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.2.6
+Version:        15.2.7
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
### Problem

The `SLE15-SP2 Real Time` base product will delivered post-GA.

* https://trello.com/c/G5AnTheC/1442-1-remove-rt-from-skelcd-control-leanos-after-alpha-6

### Solution

Not offer it to the user on the GA media.