### PR TITLE
The big SLE15-SP2 medium is called "Full" (related to jsc#SLE-7101)

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -76,7 +76,7 @@ textdomain="control"
 	<self_update_id>SLES</self_update_id>
 
 	<!-- Information about required media if the user has skipped the registration -->
-	<full_system_media_name>SLE-15-SP2-Packages</full_system_media_name>
+	<full_system_media_name>SLE-15-SP2-Full</full_system_media_name>
 	<full_system_download_url>https://download.suse.com</full_system_download_url>
 
     </globals>

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Nov 25 11:24:01 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- The big SLE15-SP2 medium is called "Full"
+  (related to jsc#SLE-7101)
+- 15.2.8
+
+-------------------------------------------------------------------
 Thu Nov 21 09:25:58 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Remove the Real Time base product (jsc#SLE-7104).

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -96,7 +96,7 @@ Requires:       sap-installation-wizard
 
 Url:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.2.7
+Version:        15.2.8
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
- The name has been updated to match the new file name
- https://jira.suse.com/browse/SLE-7101
- 15.2.8