### PR TITLE
Using tag %os_release_version

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -71,12 +71,12 @@ textdomain="control"
         </services_proposal>
 
 	<!-- self-update URL -->
-	<self_update_url>https://updates.suse.com/SUSE/Updates/SLE-INSTALLER/15-SP2/$arch/update</self_update_url>
+	<self_update_url>https://updates.suse.com/SUSE/Updates/SLE-INSTALLER/$os_release_version/$arch/update</self_update_url>
 	<!-- self-update ID. SCC recognize for SLE15 ID SLES -->
 	<self_update_id>SLES</self_update_id>
 
 	<!-- Information about required media if the user has skipped the registration -->
-	<full_system_media_name>SLE-15-SP2-Full</full_system_media_name>
+	<full_system_media_name>SLE-$os_release_version-Full</full_system_media_name>
 	<full_system_download_url>https://download.suse.com</full_system_download_url>
 
     </globals>

--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -71,11 +71,14 @@ textdomain="control"
         </services_proposal>
 
 	<!-- self-update URL -->
+	<!-- $os_release_version will be replaced by VERSION defined in /etc/os-release file (inst-sys). -->
+	<!-- $arch will be replaced by the machine architecture. -->
 	<self_update_url>https://updates.suse.com/SUSE/Updates/SLE-INSTALLER/$os_release_version/$arch/update</self_update_url>
 	<!-- self-update ID. SCC recognize for SLE15 ID SLES -->
 	<self_update_id>SLES</self_update_id>
 
 	<!-- Information about required media if the user has skipped the registration -->
+	<!-- $os_release_version will be replaced by VERSION defined in /etc/os-release file (inst-sys). -->
 	<full_system_media_name>SLE-$os_release_version-Full</full_system_media_name>
 	<full_system_download_url>https://download.suse.com</full_system_download_url>
 

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -2,7 +2,7 @@
 Wed Jan 22 15:18:19 CET 2020 - schubi@suse.de
 - Using tag $os_release_version in <self_update_url> and
   <full_system_media_name> instead of a hard coded version number.
-  This will be replaces by the value defined by VERSION in
+  This will be replaced by the value defined by VERSION in
   /etc/os-release. (improvement for fate#325834)
 - 15.2.9
 

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jan 22 15:18:19 CET 2020 - schubi@suse.de
+- Using tag $os_release_version in <self_update_url> and
+  <full_system_media_name> instead of a hard coded version number.
+  This will be replaces by the value defined by VERSION in
+  /etc/os-release. (improvement for fate#325834)
+- 15.2.9
+
+-------------------------------------------------------------------
 Mon Nov 25 11:24:01 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - The big SLE15-SP2 medium is called "Full"

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -41,7 +41,7 @@ BuildRequires:  yast2-installation-control >= 4.2.6
 
 # leanos specific Yast packages needed in the inst-sys
 # to provide the functionality needed by this control file
-Requires:       yast2-registration >= 4.0.26
+Requires:       yast2-registration >= 4.2.27
 Requires:       yast2-theme
 
 # Generic Yast packages needed for the installer
@@ -52,8 +52,8 @@ Requires:       yast2-devtools
 Requires:       yast2-fcoe-client
 # For creating the AutoYast profile at the end of installation (bnc#887406)
 Requires:       yast2-firewall
-# instsys_cleanup
-Requires:       yast2-installation >= 3.1.201
+# tag <self_update_url>
+Requires:       yast2-installation >= 4.2.28
 Requires:       yast2-iscsi-client
 Requires:       yast2-kdump
 Requires:       yast2-multipath
@@ -96,7 +96,7 @@ Requires:       sap-installation-wizard
 
 Url:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.2.8
+Version:        15.2.9
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -52,7 +52,7 @@ Requires:       yast2-devtools
 Requires:       yast2-fcoe-client
 # For creating the AutoYast profile at the end of installation (bnc#887406)
 Requires:       yast2-firewall
-# tag <self_update_url>
+# $os_release_version expansion in the <self_update_url> tag
 Requires:       yast2-installation >= 4.2.28
 Requires:       yast2-iscsi-client
 Requires:       yast2-kdump


### PR DESCRIPTION
Using tag %os_release_version instead of a  a hard coded version number in the control.xml file.