### PR TITLE
Define the default modules/extensions for the Full installation medium

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -102,6 +102,13 @@ textdomain="control"
         <!-- bnc#875350: Explicitly selecting these patterns by default -->
         <!-- For a list of patterns, see https://build.suse.de/package/view_file/SUSE:SLE-12-SP2:GA/patterns-sles/patterns-sles.spec?expand=1 -->
         <default_patterns>minimal_base</default_patterns>
+
+        <!-- the default preselected products (add-ons) for the offline Full medium installation -->
+        <!-- this is the "default default", the product specific control files usually override it -->
+        <default_modules config:type="list">
+            <default_module>sle-module-basesystem</default_module>
+        </default_modules>
+
         <!-- bnc#876760: Explicitly selecting these (optional) patterns by default if they exist -->
         <optional_default_patterns>32bit</optional_default_patterns>
 

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb 24 14:42:50 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Specify the default preselected modules in the offline
+  installation (jsc#SLE-8040, jsc#SLE-11455)
+- 15.2.10
+
+-------------------------------------------------------------------
 Wed Jan 22 15:18:19 CET 2020 - schubi@suse.de
 - Using tag $os_release_version in <self_update_url> and
   <full_system_media_name> instead of a hard coded version number.

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -96,7 +96,7 @@ Requires:       sap-installation-wizard
 
 Url:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.2.9
+Version:        15.2.10
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -31,7 +31,7 @@ Name:           skelcd-control-leanos
 # xmllint (for validation)
 BuildRequires:  libxml2-tools
 # RNG validation schema
-BuildRequires:  yast2-installation-control >= 4.2.6
+BuildRequires:  yast2-installation-control >= 4.2.9
 
 ######################################################################
 #


### PR DESCRIPTION
- Related to https://jira.suse.com/browse/SLE-8040 and https://jira.suse.com/browse/SLE-11455
- We need to specify additional default modules in the `control.xml` used in offline installation

### Note

Travis fails as it depends on https://github.com/yast/yast-installation-control/pull/93, I have tested it locally and it validates against the updated schema. I'll trigger Travis again after merging that.