### PR TITLE
Self update repo

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ end
 # the location in the inst-sys is different than in the built RPM package
 # so the usual "rake install" would not work here
 
-# running int the inst-sys?
+# running in the inst-sys?
 if File.exist?("/.packages.initrd")
   task :install do
     destdir = ENV["DESTDIR"] || "/"

--- a/Rakefile
+++ b/Rakefile
@@ -5,3 +5,19 @@ Yast::Tasks.configuration do |conf|
   conf.skip_license_check << /.*/
 end
 
+# this special part allows using the "yupdate" script with this package,
+# the location in the inst-sys is different than in the built RPM package
+# so the usual "rake install" would not work here
+
+# running int the inst-sys?
+if File.exist?("/.packages.initrd")
+  task :install do
+    destdir = ENV["DESTDIR"] || "/"
+    control = "/control.xml"
+    # backup the original file
+    FileUtils.cp(control, "#{control}.bak") if File.exist?(control)
+    # install the new file
+    FileUtils.cp("control/control.leanos.xml", File.join(destdir, control))
+  end
+end
+

--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -525,13 +525,12 @@ Please visit us at http://www.suse.com/.
                     <name>update_installer</name>
                 </module>
                 <module>
-                    <!-- skip on the Online and Offline installation medium, it is done later -->
-                    <!-- TODO: Remove this step completely once the old Installer and
-                      the non-bootable Packages DVD are dropped. -->
+                    <!-- skip on the Online installation medium, it is done later -->
+                    <!-- on the Offline we need to add the self-update add-on repository -->
                     <label>Repositories Initialization</label>
                     <name>repositories_initialization</name>
                     <arguments>
-                        <skip>online,offline</skip>
+                        <skip>online</skip>
                     </arguments>
                 </module>
                 <module>

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Apr  8 14:39:55 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Allow updating the roles via self_update repository (bsc#1168702)
+- 15.2.11
+
+-------------------------------------------------------------------
 Mon Feb 24 14:42:50 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Specify the default preselected modules in the offline

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -96,7 +96,7 @@ Requires:       sap-installation-wizard
 
 Url:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.2.10
+Version:        15.2.11
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
- See https://bugzilla.suse.com/show_bug.cgi?id=1168702
- The self-update add-on repository was not added during installation so the new/updated roles were not displayed
- Depends on https://github.com/yast/yast-packager/pull/520

### Rakefile Update

Additionally I have updated the `Rakefile` so it works correctly with the `yupdate` script in the inst-sys.

### Testing

```shell
yupdate patch yast-packager self_update_repo
yupdate patch skelcd-control-leanos self_update_repo

# edit the "SelfUpdate" value, the yupdate script automatically disables the
# self-update, write the self-update repository URL there
vim /etc/install.inf
```

Use the testing skelcd package from the bugzilla bug

### Screenshots

The original roles displayed:
![suma_roles](https://user-images.githubusercontent.com/907998/78798066-d738f900-79b8-11ea-923e-eef7c99893d8.png)

The new updated roles displayed after patching the installer:
![suma_new_roles](https://user-images.githubusercontent.com/907998/78798042-d0aa8180-79b8-11ea-9f31-815d4c88327d.png)
