### PR TITLE
[WIP] Remove the obsolete repository initialization

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -736,16 +736,6 @@ Please visit us at http://www.suse.com/.
                     <enable_back>no</enable_back>
                     <enable_next>yes</enable_next>
                 </module>
-                <module>
-                    <label>Repositories Initialization</label>
-                    <name>repositories_initialization</name>
-                    <!-- skip on the Online and Offline installation medium, it is done later -->
-                    <!-- TODO: Remove this step completely once the old Installer and
-                         the non-bootable Packages DVD are dropped. -->
-                    <arguments>
-                        <skip>online,offline</skip>
-                    </arguments>
-                </module>
                 <!-- bsc#1047060: Module used only to display a beta warning in case README.BETA
                 file exists. Other than that, the module is completely skipped in auto mode -->
                 <module>

--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -776,13 +776,6 @@ Please visit us at http://www.suse.com/.
                     <enable_back>no</enable_back>
                     <enable_next>yes</enable_next>
                 </module>
-                <module>
-                    <label>Repositories Initialization</label>
-                    <name>repositories_initialization</name>
-                    <arguments>
-                        <skip>online,offline</skip>
-                    </arguments>
-                </module>
                 <!-- bsc#1047060: Module used only to display a beta warning in case README.BETA
                 file exists. Other than that, the module is completely skipped in auto mode -->
                 <module>


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1173204
- There is a leftover in the repository initialization
- It makes troubles when using the Online medium and pointing `install=` to a different repository (e.g. the SLES product repository on the Full medium)
- It was used only for an old repository (not Online, not Offline) and should be removed now

## Testing
- Add the `startshell=1` boot option
- When the shell prompt appears run the `yupdate patch skelcd-control-leanos repo_init_cleanup` command. This will patch the `/control.xml` file with the file from this pull request
- Alternatively you can remove the section manually with `vim /control.xml`
- Then run `yast` to start the installer (or close the shell with `Ctrl+D`, then it will continue starting YaST automatically
- Do not forget to disable the signature checks in the AutoYaST XML profile (like in the [bug description](https://bugzilla.suse.com/show_bug.cgi?id=1173204#c0))

## TODO

- [x] Verify the fix by the SUMA team
- [x] Test/fix also the AutoUpgrade scenario, the same problem is very like also there...