### PR TITLE
Removed repository initialization step in AutoYaST (bsc#1173204)

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -636,10 +636,6 @@ Please visit us at http://www.suse.com/.
                     <enable_back>no</enable_back>
                     <enable_next>yes</enable_next>
                 </module>
-                <module>
-                    <label>Repositories Initialization</label>
-                    <name>repositories_initialization</name>
-                </module>
                 <!-- bsc#1047060: Module used only to display a beta warning in case README.BETA
                 file exists. Other than that, the module is completely skipped in auto mode -->
                 <module>
@@ -679,10 +675,6 @@ Please visit us at http://www.suse.com/.
                     <name>update_installer</name>
                     <enable_back>no</enable_back>
                     <enable_next>yes</enable_next>
-                </module>
-                <module>
-                    <label>Repositories Initialization</label>
-                    <name>repositories_initialization</name>
                 </module>
                 <!-- bsc#1047060: Module used only to display a beta warning in case README.BETA
                 file exists. Other than that, the module is completely skipped in auto mode -->

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jun 25 10:41:30 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Removed a not needed repository initialization step in AutoYaST,
+  it causes problems with unsigned repositories used by SUSE
+  Manager (bsc#1173204)
+- 15.1.5
+
+-------------------------------------------------------------------
 Mon Sep 30 15:13:04 CEST 2019 - schubi@suse.de
 
 - Added "security" to "clone_module" section (bsc#1150821).

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -96,7 +96,7 @@ Requires:       sap-installation-wizard
 
 Url:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.1.4
+Version:        15.1.5
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1173204 (reported for SP2 but the very same problem exists also in SP1)
- Pointing `install=` to an unsigned repository does not work properly, YaST reports a signature error although the signature checks are disabled in the AutoYaST profile.
- That repository initialization is actually not needed, the repository is properly initialized later
- It causes problems with unsigned repositories, the AutoYaST profile is not read yet at that point and the signature checks are still enabled
- 15.1.5

## Tests

- Tested manually (both AutoYaST installation and upgrade cases)
- The SP2 fix has been verified by @mcalmer (see https://github.com/yast/skelcd-control-leanos/pull/55)