### PR TITLE
Removed repository initialization step in AutoYaST (bsc#1173204) [SP1-QR]

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -159,6 +159,7 @@ textdomain="control"
         <clone_module>ntp-client</clone_module>
         <clone_module>ssh_import</clone_module>
         <clone_module>tftp-server</clone_module>
+        <clone_module>security</clone_module>
 <!--
         <clone_module>scc</clone_module>
 -->

--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -636,10 +636,6 @@ Please visit us at http://www.suse.com/.
                     <enable_back>no</enable_back>
                     <enable_next>yes</enable_next>
                 </module>
-                <module>
-                    <label>Repositories Initialization</label>
-                    <name>repositories_initialization</name>
-                </module>
                 <!-- bsc#1047060: Module used only to display a beta warning in case README.BETA
                 file exists. Other than that, the module is completely skipped in auto mode -->
                 <module>
@@ -679,10 +675,6 @@ Please visit us at http://www.suse.com/.
                     <name>update_installer</name>
                     <enable_back>no</enable_back>
                     <enable_next>yes</enable_next>
-                </module>
-                <module>
-                    <label>Repositories Initialization</label>
-                    <name>repositories_initialization</name>
                 </module>
                 <!-- bsc#1047060: Module used only to display a beta warning in case README.BETA
                 file exists. Other than that, the module is completely skipped in auto mode -->

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Sep 30 15:13:04 CEST 2019 - schubi@suse.de
+
+- Added "security" to "clone_module" section (bsc#1150821).
+- 15.1.4
+
+-------------------------------------------------------------------
 Tue Mar 12 14:59:23 UTC 2019 - David Díaz <dgonzalez@suse.com>
 
 - Updated the base product license directory

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jun 25 10:41:30 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Removed a not needed repository initialization step in AutoYaST,
+  it causes problems with unsigned repositories used by SUSE
+  Manager (bsc#1173204)
+- 15.1.5
+
+-------------------------------------------------------------------
 Mon Sep 30 15:13:04 CEST 2019 - schubi@suse.de
 
 - Added "security" to "clone_module" section (bsc#1150821).

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -96,7 +96,7 @@ Requires:       sap-installation-wizard
 
 Url:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.1.3
+Version:        15.1.4
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -96,7 +96,7 @@ Requires:       sap-installation-wizard
 
 Url:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.1.4
+Version:        15.1.5
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
- Same as in https://github.com/yast/skelcd-control-leanos/pull/56
- Just porting to the quarterly media respin branch
- To versioning: SP1-MU contains 15.1.5 so use 15.1.5.1 for the QR branch