### PR TITLE
Clone suse register

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -233,9 +233,7 @@ textdomain="control"
         <clone_module>ssh_import</clone_module>
         <clone_module>tftp-server</clone_module>
         <clone_module>security</clone_module>
-<!--
-        <clone_module>scc</clone_module>
--->
+        <clone_module>suse_register</clone_module>
     </clone_modules>
 
     <texts>

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Sep 24 11:10:11 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Clone the <suse_register/> section (bsc#1174202).
+- 15.3.1
+
+-------------------------------------------------------------------
 Tue Aug 11 07:20:38 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Adapt the products to SLE-15-SP3 (bsc#1175093)

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -96,7 +96,7 @@ Requires:       sap-installation-wizard
 
 Url:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.3.0
+Version:        15.3.1
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
Clone the <suse_register/> section.

Trello: https://trello.com/c/jzih5O43/1928-8-export-registered-add-ons-properly
Bug: https://bugzilla.suse.com/show_bug.cgi?id=1174202