### PR TITLE
AY: write linuxrc proxy and hostname to inst-sys

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -736,6 +736,11 @@ Please visit us at http://www.suse.com/.
                 <enable_next>no</enable_next>
             </defaults>
             <modules config:type="list">
+                <module>
+                    <!-- writes hostname and proxy config bsc#1177768 -->
+                    <label>Load Linuxrc Network Configuration</label>
+                    <name>install_inf</name>
+                </module>
                 <!-- As soon as possible -->
                 <module>
                     <label>Installer Update</label>

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Oct 29 10:08:09 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Write linuxrc hostname and proxy configuration also during an
+  autoinstallation (bsc#1177768)
+- 15.2.14
+
+-------------------------------------------------------------------
 Wed Sep  9 06:58:35 UTC 2020 - Jeffrey Cheung <jcheung@suse.com>
 
 - Add RT15 SP2 base product (jsc#SLE-16203)

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -96,7 +96,7 @@ Requires:       sap-installation-wizard
 
 Url:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.2.13
+Version:        15.2.14
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
## Problem

During an autoinstallation, if the networking section only contains the `keep_install_network` option it should copy the network configuration from linuxrc to the target system. This is not the case of the hostname option which is lost.

-https://bugzilla.suse.com/show_bug.cgi?id=1177768

## Solution

Add the install_inf client to be run also in autoinstallation