### PR TITLE
Fixed download URL (related to bsc#1177504)

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -84,7 +84,7 @@ textdomain="control"
 	<!-- Information about required media if the user has skipped the registration -->
 	<!-- $os_release_version will be replaced by VERSION defined in /etc/os-release file (inst-sys). -->
 	<full_system_media_name>SLE-$os_release_version-Full</full_system_media_name>
-	<full_system_download_url>https://download.suse.com</full_system_download_url>
+	<full_system_download_url>https://www.suse.com/download/</full_system_download_url>
 
     </globals>
 

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Dec 18 15:57:56 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed download URL (related to bsc#1177504)
+- 15.3.5
+
+-------------------------------------------------------------------
 Tue Nov 24 09:45:58 UTC 2020 - Julio González Gil <jgonzalez@suse.com>
 
 - Update the definitions for SUSE Manager 4.2 (bsc#1179134)

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -96,7 +96,7 @@ Requires:       sap-installation-wizard
 
 Url:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.3.4
+Version:        15.3.5
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
- Update the download URL displayed in the registration popup
- The old URL redirects to the new one (at least now), but we should use the new URL directly