### PR TITLE
Default ntp servers

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -41,6 +41,13 @@ textdomain="control"
         <show_addons config:type="boolean">true</show_addons>
         <addons_default config:type="boolean">true</addons_default>
 
+        <default_ntp_servers config:type="list">
+          <ntp_server>0.suse.pool.ntp.org</ntp_server>
+          <ntp_server>1.suse.pool.ntp.org</ntp_server>
+          <ntp_server>2.suse.pool.ntp.org</ntp_server>
+          <ntp_server>3.suse.pool.ntp.org</ntp_server>
+        </ntp_servers>
+
         <!-- FATE #301937, Save /root content from the installation system to the installed system -->
         <save_instsys_content config:type="list">
             <save_instsys_item>

--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -46,7 +46,7 @@ textdomain="control"
           <ntp_server>1.suse.pool.ntp.org</ntp_server>
           <ntp_server>2.suse.pool.ntp.org</ntp_server>
           <ntp_server>3.suse.pool.ntp.org</ntp_server>
-        </ntp_servers>
+        </default_ntp_servers>
 
         <!-- FATE #301937, Save /root content from the installation system to the installed system -->
         <save_instsys_content config:type="list">

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jan 11 16:15:55 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
+
+- Define default ntp servers for SLE products (bsc#1180699)
+- 15.3.6
+
+-------------------------------------------------------------------
 Fri Dec 18 15:57:56 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed download URL (related to bsc#1177504)

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -96,7 +96,7 @@ Requires:       sap-installation-wizard
 
 Url:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.3.5
+Version:        15.3.6
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -31,7 +31,7 @@ Name:           skelcd-control-leanos
 # xmllint (for validation)
 BuildRequires:  libxml2-tools
 # RNG validation schema
-BuildRequires:  yast2-installation-control >= 4.3.7
+BuildRequires:  yast2-installation-control >= 4.3.8
 
 ######################################################################
 #


### PR DESCRIPTION
trello: https://trello.com/c/HtBLfvR0/4499-ostumbleweed-p5-1180699-microos-defaults-to-using-the-suse-ntp-pool
bzilla: https://bugzilla.suse.com/show_bug.cgi?id=1180699

related https://github.com/yast/yast-installation-control/pull/105