### PR TITLE
Update security settings

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -74,18 +74,17 @@ textdomain="control"
             </service>
         </services_proposal>
 
-	<!-- self-update URL -->
-	<!-- $os_release_version will be replaced by VERSION defined in /etc/os-release file (inst-sys). -->
-	<!-- $arch will be replaced by the machine architecture. -->
-	<self_update_url>https://updates.suse.com/SUSE/Updates/SLE-INSTALLER/$os_release_version/$arch/update</self_update_url>
-	<!-- self-update ID. SCC recognize for SLE15 ID SLES -->
-	<self_update_id>SLES</self_update_id>
+        <!-- self-update URL -->
+        <!-- $os_release_version will be replaced by VERSION defined in /etc/os-release file (inst-sys). -->
+        <!-- $arch will be replaced by the machine architecture. -->
+        <self_update_url>https://updates.suse.com/SUSE/Updates/SLE-INSTALLER/$os_release_version/$arch/update</self_update_url>
+        <!-- self-update ID. SCC recognize for SLE15 ID SLES -->
+        <self_update_id>SLES</self_update_id>
 
-	<!-- Information about required media if the user has skipped the registration -->
-	<!-- $os_release_version will be replaced by VERSION defined in /etc/os-release file (inst-sys). -->
-	<full_system_media_name>SLE-$os_release_version-Full</full_system_media_name>
-	<full_system_download_url>https://www.suse.com/download/</full_system_download_url>
-
+        <!-- Information about required media if the user has skipped the registration -->
+        <!-- $os_release_version will be replaced by VERSION defined in /etc/os-release file (inst-sys). -->
+        <full_system_media_name>SLE-$os_release_version-Full</full_system_media_name>
+        <full_system_download_url>https://www.suse.com/download/</full_system_download_url>
     </globals>
 
     <software>

--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -306,8 +306,9 @@ Please visit us at http://www.suse.com/.
                     <name>default_target</name>
                     <presentation_order>75</presentation_order>
                 </proposal_module>
+                <!-- security proposal including firewall, cpu mitigation, selinux and polkit -->
                 <proposal_module>
-                    <name>firewall</name>
+                    <name>security</name>
                     <presentation_order>50</presentation_order>
                 </proposal_module>
                 <!-- Fate #319624 - proposal and dialog for existing SSH host keys -->
@@ -362,8 +363,9 @@ Please visit us at http://www.suse.com/.
                     <name>default_target</name>
                     <presentation_order>75</presentation_order>
                 </proposal_module>
+                <!-- security proposal including firewall, cpu mitigation, selinux and polkit -->
                 <proposal_module>
-                    <name>firewall</name>
+                    <name>security</name>
                     <presentation_order>50</presentation_order>
                 </proposal_module>
                 <!-- Fate #319624 - proposal and dialog for existing SSH host keys -->

--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -85,6 +85,12 @@ textdomain="control"
         <!-- $os_release_version will be replaced by VERSION defined in /etc/os-release file (inst-sys). -->
         <full_system_media_name>SLE-$os_release_version-Full</full_system_media_name>
         <full_system_download_url>https://www.suse.com/download/</full_system_download_url>
+
+        <!-- Set SELinux disabled mode by default -->
+        <selinux>
+          <mode>disabled</mode>
+          <configurable config:type="boolean">true</configurable>
+        </selinux>
     </globals>
 
     <software>

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Feb 25 09:25:23 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Set SELinux disabled mode by default (related to jsc#SLE-17307)
+- Replace firewall with a new security proposal and finish clients
+  that contain also configuration for cpu mitigation, policy kit
+  default privileges (jsc#SLE-15840) and SELinux mode (jsc#SLE-17307)
+- 15.3.6
+
+-------------------------------------------------------------------
 Fri Dec 18 15:57:56 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed download URL (related to bsc#1177504)

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -96,7 +96,7 @@ Requires:       sap-installation-wizard
 
 Url:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.3.5
+Version:        15.3.6
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
Related to features https://jira.suse.com/browse/SLE-17307 and https://jira.suse.com/browse/SLE-15840 (internal links), this PR:

* sets SELinux as a major [**L**inux **S**ecurity **M**odule](https://www.kernel.org/doc/html/latest/admin-guide/LSM/index.html) in its ~~permissive~~ **disabled** mode (see https://github.com/yast/skelcd-control-leanos/pull/74#issuecomment-786561250)  
*  replaces the firewall proposal and finish clients with the new security proposal and finish clients, which manage configuration for cpu mitigation, policy kit default privileges, and SELinux mode (see https://github.com/yast/yast-installation/pull/906)

--- 

Also related to

* Related to https://github.com/yast/yast-security/pull/87
* https://github.com/yast/skelcd-control-openSUSE/pull/227 (openSUSE Leap)
* https://github.com/yast/skelcd-control-openSUSE/pull/228 (openSUSE Tumbleweed)