### PR TITLE
Deactivate the UI for configuring SELinux

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -89,7 +89,7 @@ textdomain="control"
         <!-- Set SELinux disabled mode by default -->
         <selinux>
           <mode>disabled</mode>
-          <configurable config:type="boolean">true</configurable>
+          <configurable config:type="boolean">false</configurable>
         </selinux>
     </globals>
 

--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -89,6 +89,7 @@ textdomain="control"
         <!-- Set SELinux disabled mode by default -->
         <selinux>
           <mode>disabled</mode>
+          <!-- Not configurable because of https://bugzilla.suse.com/show_bug.cgi?id=1184215 -->
           <configurable config:type="boolean">false</configurable>
         </selinux>
     </globals>

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Apr 28 09:28:04 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Deactivate the UI for configuring SELinux (bsc#1184215)
+- 15.3.8
+
+-------------------------------------------------------------------
 Tue Mar 30 08:50:22 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Move security proposal so it can propoperly propose software

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -96,7 +96,7 @@ Requires:       sap-installation-wizard
 
 Url:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.3.7
+Version:        15.3.8
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
After a long discussion (see https://bugzilla.suse.com/show_bug.cgi?id=1184215) it has been decided to deactivate the UI for configuring SELinux by default in SLE products.

Changes has been tested manually using an `SLE-15-SP3-Online-x86_64-Snapshot15-Media1` ISO. The installation didn't offer the SELinux UI and finished successfully, with apparently healthy bootable system.

| Installation Summary | Security Settings |
|-|-|
| ![SLES-15-SP3 installation summary](https://user-images.githubusercontent.com/1691872/116383910-35788a00-a80f-11eb-80fb-39a0e12998ba.png) | ![SLES-15-SP3 security settings](https://user-images.githubusercontent.com/1691872/116383942-432e0f80-a80f-11eb-9150-ce163b54392d.png) | 

---

* SLE-15-SP2_GA SR: https://build.suse.de/request/show/240311
* SLE-15-SP3_UPDATE SR: https://build.suse.de/request/show/240299

---

<sub>Trello card (internal link): https://trello.com/c/p4eIgQMz/2408-3-important-selinux-in-sle-15-sp3</sub>