### PR TITLE
No More Upgrade from SLE-11

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -112,9 +112,9 @@ textdomain="control"
             <regexp_item>^SUSE (LINUX|Linux) Enterprise Server 12.*$</regexp_item>
         </silently_downgrade_packages_reverse_list>
 
-        <!-- Upgrading from SLES, SLED, SLE4SAP is supported, otherwise a warning is displayed -->
+        <!-- Upgrading from SLES, SLED, SLE4SAP in versions 12 and 15 is supported, otherwise a warning is displayed -->
         <products_supported_for_upgrade config:type="list">
-            <regexp_item>^SUSE (LINUX|Linux) Enterprise.*$</regexp_item>
+            <regexp_item>^SUSE (LINUX|Linux) Enterprise.*(12|15).*$</regexp_item>
         </products_supported_for_upgrade>
 
         <selection_type config:type="symbol">auto</selection_type>

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jan 17 11:47:16 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
+
+- No more support for upgrading from SLE 11, now requiring a 
+  SLE 15 or 12 based product (jsc#SLE-20518)
+- 15.4.5
+
+-------------------------------------------------------------------
 Tue Dec 28 10:20:27 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Added 'lsm' section for selecting and configuring the desired

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -96,7 +96,7 @@ Requires:       sap-installation-wizard
 
 URL:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.4.4
+Version:        15.4.5
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
## Trello

https://trello.com/c/pmYtrzEs/


## Jira

https://jira.suse.com/browse/SLE-20518

From SLE-15 SP4 on, we no longer support upgrading from SLE-11. The minimum requirement is now a SLE-15 or SLE-12 based product.


## Implementation

This changes the regexp for determining what installed systems are eligible for an upgrade, based on `/etc/os-release` on those partitions.

It used to be
`^SUSE (LINUX|Linux) Enterprise.*$`

now it's
`^SUSE (LINUX|Linux) Enterprise.*(12|15).*$`

Notice there was no version number at all previously, now it can be `12` or `15`. Also notice that the name may be more specific, such as _"SUSE Linux Enterprise Server 15 SP2"_ or _"SUSE Linux Enterprise Desktop 12 SP3"_.


## Why in this Repository?

The _control.xml_ file from this _skelcd-control-leanos_ is the smallest common denominator between all current SLE based products that can be upgraded, and as such it is the initial control file on installation media before a product is even selected; so this is the starting point for selecting partitions that can be upgraded from.