### PR TITLE
Make LSM configurable during the installation (jsc#SLE-22069)

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -88,7 +88,7 @@ textdomain="control"
 
         <lsm>
           <select>apparmor</select>
-          <configurable config:type="boolean">false</configurable>
+          <configurable config:type="boolean">true</configurable>
           <!-- Set SELinux disabled mode by default -->
           <apparmor>
             <!-- Not configurable because of https://bugzilla.suse.com/show_bug.cgi?id=1184215 -->

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Feb 11 10:06:57 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- Make LSM configurable during the installation (jsc#SLE-22069)
+- 15.4.6
+
+-------------------------------------------------------------------
 Mon Jan 17 11:47:16 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
 
 - No more support for upgrading from SLE 11, now requiring a 

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -96,7 +96,7 @@ Requires:       sap-installation-wizard
 
 URL:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.4.5
+Version:        15.4.6
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
Requested by **[SLE-21042](https://jira.suse.com/browse/SLE-21042)** the user will be able to select between **AppArmor** or **None**. **SELinux** is not selectable by now until we have a **SELinux** pattern providing a default policy in **SLES**.

## Screenshots

| Not Configurable | Configurable |
| --------- | ------ |
| ![Screenshot_testing_2022-02-11_13:51:11](https://user-images.githubusercontent.com/7056681/153604027-a8b65fc4-bab7-4dc9-b3af-ddba8a2e06f7.png) | ![Screenshot_testing_2022-02-11_13:55:41](https://user-images.githubusercontent.com/7056681/153604047-43717e07-099a-4a01-9a96-52f1fb0ae834.png) |
| ![Screenshot_testing_2022-02-11_13:51:17](https://user-images.githubusercontent.com/7056681/153604036-596547e0-a1ac-4ac7-8e62-b6cb20d1963a.png) | ![Screenshot_testing_2022-02-11_13:55:48](https://user-images.githubusercontent.com/7056681/153604061-65c3d2ab-b37d-4859-93e8-2efd5ebaea99.png) |

