### PR TITLE
Disable YaST self-update on the quarterly media updates (bsc#1201467)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,12 @@
 require "yast/rake"
 
-Yast::Tasks.submit_to :sle15sp4
-
 Yast::Tasks.configuration do |conf|
+  # submit to the specific QR project, not to standard SP4
+  conf.obs_api = "https://api.suse.de"
+  conf.obs_target = "SUSE_SLE-15-SP4_Update_QR"
+  conf.obs_sr_project = "SUSE:SLE-15-SP4:Update:QR"
+  conf.obs_project = "Devel:YaST:SLE-15-SP4-QR"
+
   # lets ignore license check for now
   conf.skip_license_check << /.*/
 end

--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -74,12 +74,15 @@ textdomain="control"
             </service>
         </services_proposal>
 
+        <!-- Note: the self update step ("update_installer") is disabled
+             for quarterly media respins, the data below would be ignored anyway. -->
+
         <!-- self-update URL -->
         <!-- $os_release_version will be replaced by VERSION defined in /etc/os-release file (inst-sys). -->
         <!-- $arch will be replaced by the machine architecture. -->
-        <self_update_url>https://updates.suse.com/SUSE/Updates/SLE-INSTALLER/$os_release_version/$arch/update</self_update_url>
+        <!-- <self_update_url>https://updates.suse.com/SUSE/Updates/SLE-INSTALLER/$os_release_version/$arch/update</self_update_url> -->
         <!-- self-update ID. SCC recognize for SLE15 ID SLES -->
-        <self_update_id>SLES</self_update_id>
+        <!-- <self_update_id>SLES</self_update_id> -->
 
         <!-- Information about required media if the user has skipped the registration -->
         <!-- $os_release_version will be replaced by VERSION defined in /etc/os-release file (inst-sys). -->
@@ -542,10 +545,14 @@ Please visit us at http://www.suse.com/.
                     <name>setup_dhcp</name>
                 </module>
                 <!-- As soon as possible but after network is initialized -->
+                <!-- Disabled for quarterly media respins, there is in an updated inst-sys
+                     which might contain newer packages than the self update repository -->
+                <!--
                 <module>
                     <label>Installer Update</label>
                     <name>update_installer</name>
                 </module>
+                -->
                 <module>
                     <name>complex_welcome</name>
                     <label>Welcome</label>
@@ -614,10 +621,14 @@ Please visit us at http://www.suse.com/.
                     <name>setup_dhcp</name>
                 </module>
                 <!-- As soon as possible but after network is initialized -->
+                <!-- Disabled for quarterly media respins, there is in an updated inst-sys
+                     which might contain newer packages than the self update repository -->
+                <!--
                 <module>
                     <label>Installer Update</label>
                     <name>update_installer</name>
                 </module>
+                -->
                 <module>
                     <name>complex_welcome</name>
                     <label>Welcome</label>
@@ -737,12 +748,16 @@ Please visit us at http://www.suse.com/.
                     <name>install_inf</name>
                 </module>
                 <!-- As soon as possible -->
+                <!-- Disabled for quarterly media respins, there is in an updated inst-sys
+                     which might contain newer packages than the self update repository -->
+                <!--
                 <module>
                     <label>Installer Update</label>
                     <name>update_installer</name>
                     <enable_back>no</enable_back>
                     <enable_next>yes</enable_next>
                 </module>
+                -->
                 <!-- bsc#1047060: Module used only to display a beta warning in case README.BETA
                 file exists. Other than that, the module is completely skipped in auto mode -->
                 <module>
@@ -777,12 +792,16 @@ Please visit us at http://www.suse.com/.
             <stage>initial</stage>
             <modules config:type="list">
                 <!-- As soon as possible -->
+                <!-- Disabled for quarterly media respins, there is in an updated inst-sys
+                     which might contain newer packages than the self update repository -->
+                <!--
                 <module>
                     <label>Installer Update</label>
                     <name>update_installer</name>
                     <enable_back>no</enable_back>
                     <enable_next>yes</enable_next>
                 </module>
+                -->
                 <!-- bsc#1047060: Module used only to display a beta warning in case README.BETA
                 file exists. Other than that, the module is completely skipped in auto mode -->
                 <module>

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jul 13 13:55:45 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Disable YaST self-update on the quarterly media updates
+  (bsc#1201467)
+- 15.4.6.1
+
+-------------------------------------------------------------------
 Fri Feb 11 10:06:57 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Make LSM configurable during the installation (jsc#SLE-22069)

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -96,7 +96,7 @@ Requires:       sap-installation-wizard
 
 URL:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.4.6
+Version:        15.4.6.1
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION

## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1201467
- Similar to #77
- We need to disable the self-update step on the QU media

## Solution

- Just comment out the `update_installer` step like we did in the past
- Update `Rakefile` so the package is correctly submitted

