### PR TITLE
Added "kdump" dependency

### DIFF
--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jul 26 14:07:58 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Added "kdump" dependency, yast2-kdump only has a runtime
+  depenency but the package is also needed in the inst-sys
+  (related to bsc#1199840)
+- 15.5.1
+
+-------------------------------------------------------------------
 Wed Apr 06 13:24:58 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 15.5.0 (bsc#1198109)

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -22,7 +22,7 @@
 #   in build service directly, use
 #   https://github.com/yast/skelcd-control-leanos repository
 #
-#   See https://github.com/yast/skelcd-control-leanos/blob/master/CONTRIBUTING.md
+#   See https://github.com/yast/.github/blob/master/CONTRIBUTING.md
 #   for more details.
 #
 ######################################################################
@@ -56,6 +56,8 @@ Requires:       yast2-firewall
 Requires:       yast2-installation >= 4.2.28
 Requires:       yast2-iscsi-client
 Requires:       yast2-kdump
+# yast2-kdump has only runtime dependency but the package is also needed in the inst-sys
+Requires:       kdump
 Requires:       yast2-multipath
 Requires:       yast2-network >= 3.1.42
 Requires:       yast2-nfs-client
@@ -96,7 +98,7 @@ Requires:       sap-installation-wizard
 
 URL:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.5.0
+Version:        15.5.1
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
- Related to https://github.com/yast/yast-kdump/pull/128, `yast2-kdump` now uses a runtime dependency
- But we also need the `kdump` package in the inst-sys ([bsc#875765#c4](https://bugzilla.suse.com/show_bug.cgi?id=875765#c4))
- So add it explicitly here