### PR TITLE
Enable the security policy support

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -313,6 +313,10 @@ Please visit us at http://www.suse.com/.
                     <name>security</name>
                     <presentation_order>50</presentation_order>
                 </proposal_module>
+                <proposal_module>
+                    <name>security_policy</name>
+                    <presentation_order>51</presentation_order>
+                </proposal_module>
                 <!-- software proposal should be computed almost at the end -->
                 <proposal_module>
                     <name>software</name>
@@ -370,6 +374,10 @@ Please visit us at http://www.suse.com/.
                 <proposal_module>
                     <name>security</name>
                     <presentation_order>50</presentation_order>
+                </proposal_module>
+                <proposal_module>
+                    <name>security_policy</name>
+                    <presentation_order>51</presentation_order>
                 </proposal_module>
                 <!-- software proposal should be computed almost at the end -->
                 <proposal_module>
@@ -449,6 +457,10 @@ Please visit us at http://www.suse.com/.
                     <name>ssh_import</name>
                     <presentation_order>80</presentation_order>
                 </proposal_module>
+                <proposal_module>
+                    <name>security_policy</name>
+                    <presentation_order>51</presentation_order>
+                </proposal_module>
             </proposal_modules>
 
             <proposal_tabs config:type="list">
@@ -459,6 +471,7 @@ Please visit us at http://www.suse.com/.
                         <proposal_module>partitions</proposal_module>
                         <proposal_module>software</proposal_module>
                         <proposal_module>language_simple</proposal_module>
+                        <proposal_module>security_policy</proposal_module>
                     </proposal_modules>
                 </proposal_tab>
 

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Nov 11 15:20:11 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add support for DISA STIG security policy validation
+  (jsc#SLE-24764).
+- 15.4.7
+
+-------------------------------------------------------------------
 Fri Feb 11 10:06:57 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Make LSM configurable during the installation (jsc#SLE-22069)

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -96,7 +96,7 @@ Requires:       sap-installation-wizard
 
 URL:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.4.6
+Version:        15.4.7
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -75,6 +75,8 @@ Requires:       yast2-x11
 Requires:       rubygem(%{rb_default_ruby_abi}:byebug)
 # Install and enable xrdp by default (FATE#320363)
 Requires:       yast2-rdp
+# Support for security policies (jsc#SLE-24764)
+Requires:       yast2-security >= 4.4.15
 
 # Architecture specific packages
 #


### PR DESCRIPTION
Enable the security policy support. See https://github.com/yast/yast-security/pull/128 for further details.

Open question: which is the right target? `SLE-15-SP4` or `SLE-15-SP4-QR`?