### PR TITLE
Remove the SUMA products (bsc#1207283, jsc#PED-2973)

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -194,27 +194,6 @@ textdomain="control"
             <register_target>sle-15-$arch</register_target>
             <archs>x86_64</archs>
           </base_product>
-          <base_product>
-            <display_name>SUSE Manager Server 4.4</display_name>
-            <name>SUSE-Manager-Server</name>
-            <version>4.4</version>
-            <register_target>sle-15-$arch</register_target>
-            <archs>ppc64le,s390x,x86_64</archs>
-          </base_product>
-          <base_product>
-            <display_name>SUSE Manager Proxy 4.4</display_name>
-            <name>SUSE-Manager-Proxy</name>
-            <version>4.4</version>
-            <register_target>sle-15-$arch</register_target>
-            <archs>x86_64</archs>
-          </base_product>
-          <base_product>
-            <display_name>SUSE Manager Retail Branch Server 4.4</display_name>
-            <name>SUSE-Manager-Retail-Branch-Server</name>
-            <version>4.4</version>
-            <register_target>sle-15-$arch</register_target>
-            <archs>x86_64</archs>
-          </base_product>
         </base_products>
     </software>
 

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Feb  7 12:59:23 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- Remove the SUMA products from the Online medium product selection
+  (bsc#1207283, jsc#PED-2973)
+- 15.5.4
+
+-------------------------------------------------------------------
 Tue Aug 04 13:07:58 UTC 2022 - Stefan Weiberg <sweiberg@suse.com>
 
 - Adapt control file for SUMA 4.4 (bsc#1202139)

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -98,7 +98,7 @@ Requires:       sap-installation-wizard
 
 URL:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.5.3
+Version:        15.5.4
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION

## Problem

- The SUMA products should not be offered on the Online SLE15-SP5 medium
- See more details in [bsc#1207283](https://bugzilla.suse.com/show_bug.cgi?id=1207283) or [jsc#PED-2973](https://jira.suse.com/browse/PED-2973)


## Solution

- Remove the SUMA products from the XML definition list


