### PR TITLE
Enable the security policy support (master/SP5)

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -299,6 +299,10 @@ Please visit us at http://www.suse.com/.
                     <name>security</name>
                     <presentation_order>50</presentation_order>
                 </proposal_module>
+                <proposal_module>
+                    <name>security_policy</name>
+                    <presentation_order>51</presentation_order>
+                </proposal_module>
                 <!-- software proposal should be computed almost at the end -->
                 <proposal_module>
                     <name>software</name>
@@ -356,6 +360,10 @@ Please visit us at http://www.suse.com/.
                 <proposal_module>
                     <name>security</name>
                     <presentation_order>50</presentation_order>
+                </proposal_module>
+                <proposal_module>
+                    <name>security_policy</name>
+                    <presentation_order>51</presentation_order>
                 </proposal_module>
                 <!-- software proposal should be computed almost at the end -->
                 <proposal_module>
@@ -435,6 +443,10 @@ Please visit us at http://www.suse.com/.
                     <name>ssh_import</name>
                     <presentation_order>80</presentation_order>
                 </proposal_module>
+                <proposal_module>
+                    <name>security_policy</name>
+                    <presentation_order>51</presentation_order>
+                </proposal_module>
             </proposal_modules>
 
             <proposal_tabs config:type="list">
@@ -445,6 +457,7 @@ Please visit us at http://www.suse.com/.
                         <proposal_module>partitions</proposal_module>
                         <proposal_module>software</proposal_module>
                         <proposal_module>language_simple</proposal_module>
+                        <proposal_module>security_policy</proposal_module>
                     </proposal_modules>
                 </proposal_tab>
 

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Feb 28 10:36:43 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add support for DISA STIG security policy validation
+  (jsc#SLE-24764).
+- 15.5.6
+
+-------------------------------------------------------------------
 Wed Feb  8 12:02:23 UTC 2023 - Jeffrey Cheung <jcheung@suse.com>
 
 - Add SLERT15 SP5 product entry to Installer (jsc#PED-3131)

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -77,6 +77,8 @@ Requires:       yast2-x11
 Requires:       rubygem(%{rb_default_ruby_abi}:byebug)
 # Install and enable xrdp by default (FATE#320363)
 Requires:       yast2-rdp
+# Support for security policies (jsc#SLE-24764)
+Requires:       yast2-security >= 4.5.5
 
 # Architecture specific packages
 #

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -100,7 +100,7 @@ Requires:       sap-installation-wizard
 
 URL:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.5.5
+Version:        15.5.6
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
Bring #97 to `master`.

- Enable the security policy support
- Add dependency on yast2-security
- Bump version and update changes file
