### PR TITLE
Modify the security policy proposal order and add security one

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -428,6 +428,14 @@ Please visit us at http://www.suse.com/.
                     <name>timezone</name>
                     <presentation_order>45</presentation_order>
                 </proposal_module>
+                <proposal_module>
+                    <name>security</name>
+                    <presentation_order>50</presentation_order>
+                </proposal_module>
+                <proposal_module>
+                    <name>security_policy</name>
+                    <presentation_order>51</presentation_order>
+                </proposal_module>
                 <!-- software proposal should be computed almost at the end -->
                 <proposal_module>
                     <name>software</name>
@@ -442,10 +450,6 @@ Please visit us at http://www.suse.com/.
                 <proposal_module>
                     <name>ssh_import</name>
                     <presentation_order>80</presentation_order>
-                </proposal_module>
-                <proposal_module>
-                    <name>security_policy</name>
-                    <presentation_order>51</presentation_order>
                 </proposal_module>
             </proposal_modules>
 
@@ -472,6 +476,8 @@ Please visit us at http://www.suse.com/.
                         <proposal_module>software</proposal_module>
                         <proposal_module>timezone</proposal_module>
                         <proposal_module>language</proposal_module>
+                        <proposal_module>security</proposal_module>
+                        <proposal_module>security_policy</proposal_module>
                         <proposal_module>default_target</proposal_module>
                         <proposal_module>kdump</proposal_module>
                         <proposal_module>ssh_import</proposal_module>

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Oct 30 09:14:16 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
+
+- Add the security proposal to the autoyast overview and change the
+  security policy proposal order in order to be run  before the
+  software proposal (bsc#1216615)
+- 15.5.7
+
+-------------------------------------------------------------------
 Tue Feb 28 10:36:43 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add support for DISA STIG security policy validation

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -51,7 +51,7 @@ Requires:       yast2-buildtools
 Requires:       yast2-devtools
 Requires:       yast2-fcoe-client
 # For creating the AutoYast profile at the end of installation (bnc#887406)
-Requires:       yast2-firewall
+Requires:       yast2-firewall >= 4.5.1
 # $os_release_version expansion in the <self_update_url> tag
 Requires:       yast2-installation >= 4.2.28
 Requires:       yast2-iscsi-client

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -77,8 +77,8 @@ Requires:       yast2-x11
 Requires:       rubygem(%{rb_default_ruby_abi}:byebug)
 # Install and enable xrdp by default (FATE#320363)
 Requires:       yast2-rdp
-# Support for security policies (jsc#SLE-24764)
-Requires:       yast2-security >= 4.5.5
+# Do a lazy initialization of security settings (bsc#1216615)
+Requires:       yast2-security >= 4.5.7
 
 # Architecture specific packages
 #

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -100,7 +100,7 @@ Requires:       sap-installation-wizard
 
 URL:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.5.6
+Version:        15.5.7
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
## Problem

The security policy is run after the software one adding the **firewalld** package as needed but it is not shown until next run of the proposal because the order and also the security proposal is not shown.

- https://bugzilla.suse.com/show_bug.cgi?id=1216615

## Solution

In AutoYaST run the security proposal before the software one although it is shown later and also add the security proposal allowing the user to disable the firewall although it is something that could be done through the profile

## Testing

- *Tested manually*


## Screenshots

*If the fix affects the UI attach some screenshots here.*

