### PR TITLE
Drop clone proposal

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -274,10 +274,6 @@ Please visit us at http://www.suse.com/.
 
             <proposal_modules config:type="list">
                 <proposal_module>
-                    <name>clone</name>
-                    <presentation_order>95</presentation_order>
-                </proposal_module>
-                <proposal_module>
                     <name>hwinfo</name>
                     <presentation_order>90</presentation_order>
                 </proposal_module>
@@ -331,10 +327,6 @@ Please visit us at http://www.suse.com/.
             <enable_skip>no</enable_skip>
 
             <proposal_modules config:type="list">
-                <proposal_module>
-                    <name>clone</name>
-                    <presentation_order>95</presentation_order>
-                </proposal_module>
                 <proposal_module>
                     <name>cio_ignore</name>
                     <presentation_order>70</presentation_order>
@@ -392,10 +384,6 @@ Please visit us at http://www.suse.com/.
             <unique_id>auto_inst_proposal</unique_id>
 
             <proposal_modules config:type="list">
-                <proposal_module>
-                    <name>clone</name>
-                    <presentation_order>95</presentation_order>
-                </proposal_module>
                 <proposal_module>
                     <name>hwinfo</name>
                     <presentation_order>90</presentation_order>
@@ -475,7 +463,6 @@ Please visit us at http://www.suse.com/.
                         <proposal_module>default_target</proposal_module>
                         <proposal_module>kdump</proposal_module>
                         <proposal_module>ssh_import</proposal_module>
-                        <proposal_module>clone</proposal_module>
                     </proposal_modules>
                 </proposal_tab>
             </proposal_tabs>

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 10 22:11:26 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
+
+- Do not use dropped clone proposal leading to warning in logs
+  (bsc#1218700)
+- 15.6.2
+
+-------------------------------------------------------------------
 Mon Aug  7 09:07:13 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
 - Update online medium product names to SLE15-SP6 (version 15.6)

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -100,7 +100,7 @@ Requires:       sap-installation-wizard
 
 URL:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.6.1
+Version:        15.6.2
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
## Problem

There are error in yast logs that clone proposal client is not found.


## Solution

As client is dropped, do not specify it in control file.


## Testing

- *Tested manually* ( basically modify /control.xml on SP6 medium and go to proposal screen and check logs afterwards )

