### PR TITLE
Removed SLE_HPC from the Online medium installation (jsc#PED-7841)

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -174,13 +174,6 @@ textdomain="control"
             <register_target>sle-15-$arch</register_target>
           </base_product>
           <base_product>
-            <display_name>SUSE Linux Enterprise High Performance Computing 15 SP6</display_name>
-            <name>SLE_HPC</name>
-            <version>15.6</version>
-            <register_target>sle-15-$arch</register_target>
-            <archs>aarch64,x86_64</archs>
-          </base_product>
-	  <base_product>
             <display_name>SUSE Linux Enterprise Real Time 15 SP6</display_name>
             <name>SLE_RT</name>
             <version>15.6</version>

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Feb 13 12:35:48 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Removed SLE_HPC from the Online medium installation
+  (jsc#PED-7841)
+- 15.6.3
+
+-------------------------------------------------------------------
 Wed Jan 10 22:11:26 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
 
 - Do not use dropped clone proposal leading to warning in logs

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -100,7 +100,7 @@ Requires:       sap-installation-wizard
 
 URL:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.6.2
+Version:        15.6.3
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
## Problem

- In SP6 SLE-HPC won't be a separate base product, it will be replaced by SLES + HPC module
- https://jira.suse.com/browse/PED-7841

## Solution

- Remove the reference from the XML file