### PR TITLE
Use a new fallback for the self-update URL (jsc#PED-4839)

### DIFF
--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -77,7 +77,7 @@ textdomain="control"
         <!-- self-update URL -->
         <!-- $os_release_version will be replaced by VERSION defined in /etc/os-release file (inst-sys). -->
         <!-- $arch will be replaced by the machine architecture. -->
-        <self_update_url>https://updates.suse.com/SUSE/Updates/SLE-INSTALLER/$os_release_version/$arch/update</self_update_url>
+        <self_update_url>https://installer-updates.suse.com/SUSE/Updates/SLE-INSTALLER/$os_release_version/$arch/update</self_update_url>
         <!-- self-update ID. SCC recognize for SLE15 ID SLES -->
         <self_update_id>SLES</self_update_id>
 

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Mar 13 13:39:00 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Use a new fallback for the self-update URL (jsc#PED-4839)
+- 15.6.4
+
+-------------------------------------------------------------------
 Tue Feb 13 12:35:48 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Removed SLE_HPC from the Online medium installation

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -100,7 +100,7 @@ Requires:       sap-installation-wizard
 
 URL:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.6.3
+Version:        15.6.4
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
## Problem

- https://jira.suse.com/browse/PED-4839
- The request is to use a different URL for the installer self-update
- It might take quite long time for the CDN to update the content, in some cases we need to react more quickly

## Solution

- Update the URL to allow using a different provider

## Testing

- The URL https://installer-updates.suse.com/SUSE/Updates/SLE-INSTALLER/15-SP6/x86_64/update/repodata/repomd.xml works fine
