### PR TITLE
Disable YaST Installer Self-Update on SLE-15-SP6 QR media

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,12 @@ require "yast/rake"
 Yast::Tasks.submit_to :sle15sp6
 
 Yast::Tasks.configuration do |conf|
+  # submit to the specific QR project, not to standard SP6
+  conf.obs_api = "https://api.suse.de"
+  conf.obs_target = "SUSE_SLE-15-SP6_Update_QR"
+  conf.obs_sr_project = "SUSE:SLE-15-SP6:Update:QR"
+  conf.obs_project = "Devel:YaST:SLE-15-SP6-QR"
+
   # lets ignore license check for now
   conf.skip_license_check << /.*/
 end

--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -74,12 +74,15 @@ textdomain="control"
             </service>
         </services_proposal>
 
+        <!-- Note: the self update step ("update_installer") is disabled
+             for quarterly media respins, the data below would be ignored anyway. -->
+
         <!-- self-update URL -->
         <!-- $os_release_version will be replaced by VERSION defined in /etc/os-release file (inst-sys). -->
         <!-- $arch will be replaced by the machine architecture. -->
-        <self_update_url>https://installer-updates.suse.com/SUSE/Updates/SLE-INSTALLER/$os_release_version/$arch/update</self_update_url>
+        <!-- <self_update_url>https://installer-updates.suse.com/SUSE/Updates/SLE-INSTALLER/$os_release_version/$arch/update</self_update_url> -->
         <!-- self-update ID. SCC recognize for SLE15 ID SLES -->
-        <self_update_id>SLES</self_update_id>
+        <!-- <self_update_id>SLES</self_update_id> -->
 
         <!-- Information about required media if the user has skipped the registration -->
         <!-- $os_release_version will be replaced by VERSION defined in /etc/os-release file (inst-sys). -->
@@ -521,10 +524,14 @@ Please visit us at http://www.suse.com/.
                     <name>setup_dhcp</name>
                 </module>
                 <!-- As soon as possible but after network is initialized -->
+                <!-- Disabled for quarterly media respins, there is in an updated inst-sys
+                     which might contain newer packages than the self update repository -->
+                <!--
                 <module>
                     <label>Installer Update</label>
                     <name>update_installer</name>
                 </module>
+                -->
                 <module>
                     <name>complex_welcome</name>
                     <label>Welcome</label>
@@ -593,10 +600,14 @@ Please visit us at http://www.suse.com/.
                     <name>setup_dhcp</name>
                 </module>
                 <!-- As soon as possible but after network is initialized -->
+                <!-- Disabled for quarterly media respins, there is in an updated inst-sys
+                     which might contain newer packages than the self update repository -->
+                <!--
                 <module>
                     <label>Installer Update</label>
                     <name>update_installer</name>
                 </module>
+                -->
                 <module>
                     <name>complex_welcome</name>
                     <label>Welcome</label>
@@ -716,12 +727,16 @@ Please visit us at http://www.suse.com/.
                     <name>install_inf</name>
                 </module>
                 <!-- As soon as possible -->
+                <!-- Disabled for quarterly media respins, there is in an updated inst-sys
+                     which might contain newer packages than the self update repository -->
+                <!--
                 <module>
                     <label>Installer Update</label>
                     <name>update_installer</name>
                     <enable_back>no</enable_back>
                     <enable_next>yes</enable_next>
                 </module>
+                -->
                 <!-- bsc#1047060: Module used only to display a beta warning in case README.BETA
                 file exists. Other than that, the module is completely skipped in auto mode -->
                 <module>
@@ -756,12 +771,16 @@ Please visit us at http://www.suse.com/.
             <stage>initial</stage>
             <modules config:type="list">
                 <!-- As soon as possible -->
+                <!-- Disabled for quarterly media respins, there is in an updated inst-sys
+                     which might contain newer packages than the self update repository -->
+                <!--
                 <module>
                     <label>Installer Update</label>
                     <name>update_installer</name>
                     <enable_back>no</enable_back>
                     <enable_next>yes</enable_next>
                 </module>
+                -->
                 <!-- bsc#1047060: Module used only to display a beta warning in case README.BETA
                 file exists. Other than that, the module is completely skipped in auto mode -->
                 <module>

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jul  8 12:10:36 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Disable installer self-update for QR media
+- 15.6.4.1
+
+-------------------------------------------------------------------
 Wed Mar 13 13:39:00 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Use a new fallback for the self-update URL (jsc#PED-4839)

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Mon Jul  8 12:10:36 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
 
-- Disable installer self-update for QR media
+- Disable installer self-update for QR media (bsc#1227503)
 - 15.6.4.1
 
 -------------------------------------------------------------------

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -100,7 +100,7 @@ Requires:       sap-installation-wizard
 
 URL:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.6.4
+Version:        15.6.4.1
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1227503

## Trello

https://trello.com/c/9XPBneQ9/

## Problem

- Similar to #106
- We need to disable the self-update step on the SP6 QU media

## Solution

- Just comment out the `update_installer` step like we did in the past
- Update `Rakefile` so the package is submitted to the appropriate OBS project

## Related PRs

- #106 (SLE-15-SP5-QR)
- #90 (SLE-15-SP4-QR)

---------------------

## New Devel:YaST Subproject in IBS

- https://build.suse.de/show/Devel:YaST:SLE-15-SP6-QR

Only IBS, not OBS as well despite the docs at https://yastgithubio.readthedocs.io/en/latest/branching-how-to/ because there are no `-QR` subprojects at all in OBS: See https://build.opensuse.org/project/subprojects/YaST