### PR TITLE
Branch for SLE-15 SP7

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require "yast/rake"
 
-Yast::Tasks.submit_to :sle15sp6
+Yast::Tasks.submit_to :sle15sp7
 
 Yast::Tasks.configuration do |conf|
   # lets ignore license check for now

--- a/control/control.leanos.xml
+++ b/control/control.leanos.xml
@@ -161,36 +161,36 @@ textdomain="control"
           <base_product>
             <!-- hidden product -->
             <special_product config:type="boolean">true</special_product>
-            <display_name>SUSE Linux Enterprise Server 15 SP6 Business Critical Linux</display_name>
+            <display_name>SUSE Linux Enterprise Server 15 SP7 Business Critical Linux</display_name>
             <name>SLES_BCL</name>
-            <version>15.6</version>
+            <version>15.7</version>
             <register_target>sle-15-$arch</register_target>
             <archs>x86_64</archs>
           </base_product>
           <base_product>
-            <display_name>SUSE Linux Enterprise Server 15 SP6</display_name>
+            <display_name>SUSE Linux Enterprise Server 15 SP7</display_name>
             <name>SLES</name>
-            <version>15.6</version>
+            <version>15.7</version>
             <register_target>sle-15-$arch</register_target>
           </base_product>
           <base_product>
-            <display_name>SUSE Linux Enterprise Real Time 15 SP6</display_name>
+            <display_name>SUSE Linux Enterprise Real Time 15 SP7</display_name>
             <name>SLE_RT</name>
-            <version>15.6</version>
+            <version>15.7</version>
             <register_target>sle-15-$arch</register_target>
             <archs>x86_64</archs>
     	  </base_product>
           <base_product>
-            <display_name>SUSE Linux Enterprise Server for SAP Applications 15 SP6</display_name>
+            <display_name>SUSE Linux Enterprise Server for SAP Applications 15 SP7</display_name>
             <name>SLES_SAP</name>
-            <version>15.6</version>
+            <version>15.7</version>
             <register_target>sle-15-$arch</register_target>
             <archs>ppc64le,x86_64</archs>
           </base_product>
           <base_product>
-            <display_name>SUSE Linux Enterprise Desktop 15 SP6</display_name>
+            <display_name>SUSE Linux Enterprise Desktop 15 SP7</display_name>
             <name>SLED</name>
-            <version>15.6</version>
+            <version>15.7</version>
             <register_target>sle-15-$arch</register_target>
             <archs>x86_64</archs>
           </base_product>

--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jul 16 15:40:22 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Branch package for SLE-15 SP7 (bsc#1227775)
+- 15.7.0
+
+-------------------------------------------------------------------
 Wed Mar 13 13:39:00 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Use a new fallback for the self-update URL (jsc#PED-4839)

--- a/package/skelcd-control-leanos.spec
+++ b/package/skelcd-control-leanos.spec
@@ -100,7 +100,7 @@ Requires:       sap-installation-wizard
 
 URL:            https://github.com/yast/skelcd-control-leanos
 AutoReqProv:    off
-Version:        15.6.4
+Version:        15.7.0
 Release:        0
 Summary:        Leanos control file needed for installation
 License:        MIT


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1227775


## Request

Adapt this package for the upcoming SLE-15 SP7.


## Actions

- Created a Git branch SLE-15-SP7 from the existing SLE-15-SP6 branch
- Enabled branch protection in GitHub like for the SLE-15-SP6 branch
- Changed all references of (SLE-15) SP6 to SP7 in the `control.leanos.xml` file
- Changed all references of 15.6 to 15.7  in the `control.leanos.xml` file
- Changed the `submit_to` target in the toplevel `Rakefile` from sle15sp6 to sle15sp7
- Bumped the package version to 15.7.0

-----------

- Created a [Devel:YaST:SLE-15-SP7](https://build.suse.de/project/show/Devel:YaST:SLE-15-SP7) subproject in IBS
- Cloned the metadata for this new Devel:YaST:SLE-15-SP7 IBS project from the old Devel:YaST:SLE-15-SP6
- Adapted all references of SP6 to SP7 in the metadata

## To Do

- ~~Actually create the `sle15sp7` rake target~~
  _Already done in [yast-rake](https://github.com/yast/yast-rake/blob/master/data/targets.yml#L104-L108)_
- Create a YaST:SLE-15:SP7 subproject in OBS (no permissions!)
- Copy the metadata from YaST:SLE-15:SP6
- Adapt all references of SP6 to SP7 in the metadata


## To Discuss

- Should we branch all YaST packages to SLE-15-SP7 already?

  _Team decision: No, we'll wait until this cannot be avoided to avoid duplicate work with maintaining SP6 and SP7 in parallel._
