### PR TITLE
Fix the date in the changes file

### DIFF
--- a/package/skelcd-control-leanos.changes
+++ b/package/skelcd-control-leanos.changes
@@ -1,5 +1,5 @@
 -------------------------------------------------------------------
-Mon Oct 30 09:14:16 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
+Mon Sep 16 14:28:28 UTC 2024 - Knut Anderssen <kanderssen@suse.com>
 
 - Add the security proposal to the autoyast overview and change the
   security policy proposal order in order to be run  before the


### PR DESCRIPTION
## Problem

- Jenkins autosubmission failed with `%changelog not in descending chronological order` error
- The problem is that the latest entry uses year 2023 while the entries below are from year 2024


## Solution

- Use the current date for the latest entry